### PR TITLE
Remove sm90-specific compile flag to support sm89

### DIFF
--- a/coat/optimizer/kernels/setup.py
+++ b/coat/optimizer/kernels/setup.py
@@ -37,6 +37,7 @@ setup(
                     "-O3",
                     "-std=c++17",
                     "-gencode=arch=compute_90,code=compute_90",
+                    "-gencode=arch=compute_89,code=compute_89",
                     "-DTORCH_USE_CUDA_DSA",
                     "-U__CUDA_NO_HALF_OPERATORS__",
                     "-U__CUDA_NO_HALF_CONVERSIONS__",

--- a/coat/optimizer/kernels/setup.py
+++ b/coat/optimizer/kernels/setup.py
@@ -36,8 +36,6 @@ setup(
                 "nvcc": [
                     "-O3",
                     "-std=c++17",
-                    # "-gencode=arch=compute_90,code=compute_90",
-                    # "-gencode=arch=compute_89,code=compute_89",
                     "-DTORCH_USE_CUDA_DSA",
                     "-U__CUDA_NO_HALF_OPERATORS__",
                     "-U__CUDA_NO_HALF_CONVERSIONS__",

--- a/coat/optimizer/kernels/setup.py
+++ b/coat/optimizer/kernels/setup.py
@@ -36,8 +36,8 @@ setup(
                 "nvcc": [
                     "-O3",
                     "-std=c++17",
-                    "-gencode=arch=compute_90,code=compute_90",
-                    "-gencode=arch=compute_89,code=compute_89",
+                    # "-gencode=arch=compute_90,code=compute_90",
+                    # "-gencode=arch=compute_89,code=compute_89",
                     "-DTORCH_USE_CUDA_DSA",
                     "-U__CUDA_NO_HALF_OPERATORS__",
                     "-U__CUDA_NO_HALF_CONVERSIONS__",


### PR DESCRIPTION
sm89 also has FP8, and from my local testing, the code works correctly for sm89 (`tests/test_fp8_adamw_expand.py` passes).

I think the more general way to handle multiple architecture is to specify it via `TORCH_CUDA_ARCH_LIST` (PyTorch will add necessary `-gencode=...` flags), hence having explicit compile flag for sm90 is unnecessary. I propose to remove that flag. On my machine, without specifying `TORCH_CUDA_ARCH_LIST`, it will default to the current available GPUs, which is a desirable behavior I think.

If you are against it, another option is to add explicit compile flag for sm89. i.e.

```
                    "-gencode=arch=compute_90,code=compute_90",
                    "-gencode=arch=compute_90,code=sm_90",
                    "-gencode=arch=compute_89,code=compute_89",
                    "-gencode=arch=compute_89,code=sm_89",
```

(I find that I also need to add `code=sm_xx`, otherwise the embedded PTX may fail to compile if the system driver is too old).

Looking forward to your feedback!